### PR TITLE
Bundler niceties

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source "https://rubygems.org"
 
+gemspec
+
 gem "minitest"
 gem "rake"

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "reductio"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+bundle install
+
+# Do any other automated setup that you need to do here


### PR DESCRIPTION
Adds some basic bundler helper scripts that make it really easy to get up and running with development.

* `bin/console` starts a REPL with `reductio` already required, along with anything else you specify there.
* `bin/setup` runs `bundle install` (and in some cases other stuff) in a consistent setup interface.

Also adds the gemspec to the Gemfile. This makes sure that Bundler requires `reductio` and its (currently non-existant) dependencies when you call `Bundler.setup`. This helps with the `bin/console` command by auto-requiring `reductio`.